### PR TITLE
Adding google tags

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,6 +59,15 @@ const config = {
         },
       },
     ],
+        [
+      '@docusaurus/preset-classic',
+      {
+        gtag: {
+          trackingID: 'G-S6RRDF6PG8',
+          anonymizeIP: true,
+        },
+      },
+    ],
   ],
 
   plugins: [
@@ -82,6 +91,8 @@ const config = {
         editUrl: 'https://github.com/carobot/carobot.github.io/tree/main/',
       }, 
     ],
+  
+
 ],
 
   themeConfig:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-rc.1",
+    "@docusaurus/plugin-google-gtag": "^2.4.0",
     "@docusaurus/preset-classic": "2.0.0-rc.1",
     "@docusaurus/theme-search-algolia": "^2.0.0-rc.1",
     "@mdx-js/react": "^1.6.21",


### PR DESCRIPTION
this uses the g tag module which is a preset instead of manually installing the plugin, which requires frequent installation of updates, this is done through docusaurus back end server. this is mainly a logistics update